### PR TITLE
Bump jQuery version to ~1.9.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "jquery": "~1.8.0"
+    "jquery": "~1.9.0"
   },
   "main": "js/bootstrap.js"
 }


### PR DESCRIPTION
@RobLoach 

Per this release note:

http://blog.getbootstrap.com/2013/02/07/bootstrap-2-3-released/

Bootstrap 2.3 should be including jQuery 1.9.

I feel we should alter the `2.3.2` release tag to include this change as well as master. This breaks bower installs unless you pass `--force-latest` if another dependency is using 1.9
