### PR TITLE
explicitly list fonts as fonts; put css in styles field.

### DIFF
--- a/component.json
+++ b/component.json
@@ -15,8 +15,13 @@
   "scripts": [
     "js/bootstrap.js"
   ],
-  "files": [
-    "css/bootstrap.css",
-    "fonts/*"
+  "fonts": [
+    "fonts/glyphicons-halflings-regular.eot",
+    "fonts/glyphicons-halflings-regular.svg",
+    "fonts/glyphicons-halflings-regular.ttf",
+    "fonts/glyphicons-halflings-regular.woff"
+  ],
+  "styles": [
+    "css/bootstrap.css"
   ]
 }


### PR DESCRIPTION
This fix makes `component install` work again.
