### PR TITLE
Allow any jQuery version greater than 1.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "components/jquery": "1.9.*"
+    "components/jquery": ">=1.9"
   },
   "suggest": {
     "components/bootstrap-default": "Provide a theme for Bootstrap as components/bootstrap only provides the CSS as file assets"


### PR DESCRIPTION
According to the docs, Bootstrap is compatible with any jQuery version
greater than 1.9. The version should not be further restricted until
Boostrap documents a problem with a new version of jQuery.

Source: https://github.com/twbs/bootstrap/blob/master/bower.json

Fixes #8
