### PR TITLE
Replacing bootstrap.css with bootstrap.min.css.

### DIFF
--- a/component.json
+++ b/component.json
@@ -16,7 +16,7 @@
     "js/bootstrap.js"
   ],
   "styles": [
-    "css/bootstrap.min.css"
+    "css/bootstrap.css"
   ],
   "files": [
     "css/bootstrap.min.css",


### PR DESCRIPTION
Specifying the minified version of bootstrap.css so the RequireJS require.css file uses the minified version, making it smaller.

Let me know if I'm missing something, but it makes sense to use the minified CSS for require.css, since it's always loaded as part of the page load when using the RequireJS includes.
