### PR TITLE
Change jquery dependency to '*'

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,7 +9,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "components/jquery": ">=1.9.0"
+    "components/jquery": "*"
   },
   "main": "js/bootstrap.js",
   "scripts": [


### PR DESCRIPTION
Component does not support range dependencies as far as I can tell per
the spec on the Wiki. Without this change,

   $ component install -v components/bootstrap

fails with the error message

   error : failed to fetch https://raw.github.com/components/jquery/>=1.9.0/component.json, got 404 "Not Found"

Fixes #20
