### PR TITLE
Change to allow use with jQuery 1.9.1+ & 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     }
   ],
   "require": {
-    "components/jquery": ">=1.9.1"
+    "components/jquery": "~1.9.1 | ~1.10 | ~2.0"
   },
   "suggest": {
     "components/bootstrap-default": "Provide a theme for Bootstrap as components/bootstrap only provides the CSS as file assets"


### PR DESCRIPTION
Changes composer to allow use together with more recent versions of jQuery.
_Motivation: being able to use the slightly smaller and faster jQuery 2 in projects where IE 6 / 7 / 8 support is not a priority._

I don't know the format for the other package managers, so for now just added for composer.